### PR TITLE
Support for PIDs and (non-Geo)JSON-LD

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -176,7 +176,7 @@ default.
                 name: CSV
                 data: tests/data/obs.csv  # required: the data filesystem path or URL, depending on plugin setup
                 id_field: id  # required for vector data, the field corresponding to the ID
-                uri_field: uri # opetional field corresponding to the Uniform Resource Identifier (see Linked Data section)
+                uri_field: uri # optional field corresponding to the Uniform Resource Identifier (see Linked Data section)
                 time_field: datetimestamp  # optional field corresponding to the temporal property of the dataset
                 title_field: foo # optional field of which property to display as title/label on HTML pages
                 format:  # optional default format

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -242,7 +242,7 @@ For collections, at the level of an item or items, the default the JSON-LD repre
 
 The optional configuration options for collections, at the level of an item of items, are:
 
-- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If geojsonld is False, the properties block will be expanded   into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
+- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If ``geojsonld`` is False, the properties block will be expanded   into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
 - If ``uri_field`` is specied, JSON-LD will be updated such that ``@id:uri``.
 
 .. note::

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -147,7 +147,7 @@ default.
           keywords:  # list of related keywords
               - observations
               - monitoring
-          geojsonld: True # use default geojsonld behavior (see Linked Data section)
+          geojsonld: true # use default geojsonld behavior (see Linked Data section)
           context:  # linked data configuration (see Linked Data section)
               - datetime: https://schema.org/DateTime
               - vocab: https://example.com/vocab#
@@ -242,7 +242,7 @@ For collections, at the level of an item or items, the default the JSON-LD repre
 
 The optional configuration options for collections, at the level of an item of items, are:
 
-- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration presenting GeoJSON-LD. If ``geojsonld`` is False the individual item JSON-LD will conform to standard JSON-LD, and the ``@context`` will not include the geojson vocabulary, but only one specifying the ``@id`` property, the ``@type`` property, and schema.org/ vocabulary. In addition, properties block will be expanded into the main body, non-point geometry will be removed, and point-type geometry will be represented as https://schema.org geometry instead of geojson.
+- If ``geojsonld`` is not specified or is ``true``, the JSON-LD will conform to the default configuration presenting GeoJSON-LD. If ``geojsonld`` is ``false`` the individual item JSON-LD will conform to standard JSON-LD, and the ``@context`` will not include the geojson vocabulary, but only one specifying the ``@id`` property, the ``@type`` property, and schema.org/ vocabulary. In addition, properties block will be expanded into the main body, non-point geometry will be removed, and point-type geometry will be represented as https://schema.org geometry instead of geojson.
 - If ``uri_field`` is specified, JSON-LD will be updated such that ``@id:uri_field`` for each item in a collection.
 
 .. note::

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -242,7 +242,7 @@ For collections, at the level of an item or items, the default the JSON-LD repre
 
 The optional configuration options for collections, at the level of an item of items, are:
 
-- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If ``geojsonld`` is False, the properties block will be expanded into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
+- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration presenting GeoJSON-LD. If ``geojsonld`` is False the individual item JSON-LD will conform to standard JSON-LD, and the ``@context`` will not include the geojson vocabulary, but only one specifying the ``@id`` property, the ``@type`` property, and schema.org/ vocabulary. In addition, properties block will be expanded into the main body, non-point geometry will be removed, and point-type geometry will be represented as https://schema.org geometry instead of geojson.
 - If ``uri_field`` is specified, JSON-LD will be updated such that ``@id:uri_field`` for each item in a collection.
 
 .. note::

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -242,8 +242,8 @@ For collections, at the level of an item or items, the default the JSON-LD repre
 
 The optional configuration options for collections, at the level of an item of items, are:
 
-- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If ``geojsonld`` is False, the properties block will be expanded   into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
-- If ``uri_field`` is specied, JSON-LD will be updated such that ``@id:uri``.
+- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If ``geojsonld`` is False, the properties block will be expanded into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
+- If ``uri_field`` is specified, JSON-LD will be updated such that ``@id:uri`` for each item in a collection.
 
 .. note::
    While this is enough to provide valid RDF (as GeoJSON-LD), it does not allow the *properties* of your items to be

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -147,6 +147,7 @@ default.
           keywords:  # list of related keywords
               - observations
               - monitoring
+          geojsonld: True # use default geojsonld behavior (see Linked Data section)
           context:  # linked data configuration (see Linked Data section)
               - datetime: https://schema.org/DateTime
               - vocab: https://example.com/vocab#
@@ -175,6 +176,7 @@ default.
                 name: CSV
                 data: tests/data/obs.csv  # required: the data filesystem path or URL, depending on plugin setup
                 id_field: id  # required for vector data, the field corresponding to the ID
+                uri_field: uri # opetional field corresponding to the Uniform Resource Identifier (see Linked Data section)
                 time_field: datetimestamp  # optional field corresponding to the temporal property of the dataset
                 title_field: foo # optional field of which property to display as title/label on HTML pages
                 format:  # optional default format
@@ -232,11 +234,16 @@ The metadata for an instance is determined by the content of the `metadata`_ sec
 This metadata is included automatically, and is sufficient for inclusion in major indices of datasets, including the
 `Google Dataset Search`_.
 
-For collections, at the level of an item or items, by default the JSON-LD representation adds:
+For collections, at the level of an item or items, the default the JSON-LD representation adds:
 
 - The GeoJSON JSON-LD `vocabulary and context <https://geojson.org/geojson-ld/>`_ to the ``@context``.
 - An ``@id`` for each item in a collection, that is the URL for that item (resolving to its HTML representation
   in pygeoapi)
+
+The optional configuration options for collections, at the level of an item of items, are:
+
+- If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If geojsonld is False, the properties block will be expanded   into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
+- If ``uri_field`` is specied, JSON-LD will be updated such that ``@id:uri``.
 
 .. note::
    While this is enough to provide valid RDF (as GeoJSON-LD), it does not allow the *properties* of your items to be

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -243,7 +243,7 @@ For collections, at the level of an item or items, the default the JSON-LD repre
 The optional configuration options for collections, at the level of an item of items, are:
 
 - If ``geojsonld`` is not specified or is True, the JSON-LD will conform to the default configuration. If ``geojsonld`` is False, the properties block will be expanded into the main body, non-point geometry will be removed, and a custom ``@context`` will be used in the JSON-LD.
-- If ``uri_field`` is specified, JSON-LD will be updated such that ``@id:uri`` for each item in a collection.
+- If ``uri_field`` is specified, JSON-LD will be updated such that ``@id:uri_field`` for each item in a collection.
 
 .. note::
    While this is enough to provide valid RDF (as GeoJSON-LD), it does not allow the *properties* of your items to be

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -987,7 +987,7 @@ class API:
             'title': 'This document as HTML',
             'href': '{}/collections/{}/items?f=html{}'.format(
                 self.config['server']['url'], dataset, serialized_query_params)
-            }
+           }
         ]
 
         if startindex > 0:
@@ -1079,8 +1079,7 @@ class API:
             content = geojson2geojsonld(
                 self.config, content, dataset, identifier_field=(p.uri_field or 'id')
             )
-            content = to_json(content, self.pretty_print)
-            return headers_, 200, content
+            return headers_, 200, to_json(content, self.pretty_print)
 
         return headers_, 200, to_json(content, self.pretty_print)
 
@@ -1152,11 +1151,9 @@ class API:
             msg = 'identifier not found'
             return self.get_exception(400, headers_, format_, 'NotFound', msg)
 
-        if p.uri_field is not None:
-            uri = content['properties'].get( p.uri_field )
-        else:
-            uri = '{}/collections/{}/items/{}'.format(
-                self.config['server']['url'], dataset, identifier)
+        uri = content['properties'].get( p.uri_field ) if p.uri_field is not None else \
+              '{}/collections/{}/items/{}'.format( \
+              self.config['server']['url'], dataset, identifier)
         
         content['links'] = [{
             'rel': 'self' if not format_ or format_ == 'json' else 'alternate',

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -987,7 +987,7 @@ class API:
             'title': 'This document as HTML',
             'href': '{}/collections/{}/items?f=html{}'.format(
                 self.config['server']['url'], dataset, serialized_query_params)
-           }
+            }
         ]
 
         if startindex > 0:
@@ -1077,7 +1077,7 @@ class API:
         elif format_ == 'jsonld':
             headers_['Content-Type'] = 'application/ld+json'
             content = geojson2geojsonld(
-                self.config, content, dataset, identifier_field=(p.uri_field or 'id')
+                self.config, content, dataset, id_field=(p.uri_field or 'id')
             )
             return headers_, 200, to_json(content, self.pretty_print)
 
@@ -1151,10 +1151,10 @@ class API:
             msg = 'identifier not found'
             return self.get_exception(400, headers_, format_, 'NotFound', msg)
 
-        uri = content['properties'].get( p.uri_field ) if p.uri_field is not None else \
-              '{}/collections/{}/items/{}'.format( \
-              self.config['server']['url'], dataset, identifier)
-        
+        uri = content['properties'].get(p.uri_field) if p.uri_field else \
+            '{}/collections/{}/items/{}'.format(
+                self.config['server']['url'], dataset, identifier)
+
         content['links'] = [{
             'rel': 'self' if not format_ or format_ == 'json' else 'alternate',
             'type': 'application/geo+json',

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -987,7 +987,7 @@ class API:
             'title': 'This document as HTML',
             'href': '{}/collections/{}/items?f=html{}'.format(
                 self.config['server']['url'], dataset, serialized_query_params)
-            }
+           }
         ]
 
         if startindex > 0:
@@ -1045,9 +1045,11 @@ class API:
             content['collections_path'] = '/'.join(path_info.split('/')[:-2])
             content['startindex'] = startindex
 
+            if p.uri_field is not None:
+                content['uri_field'] = p.uri_field
             if p.title_field is not None:
                 content['title_field'] = p.title_field
-            content['id_field'] = p.uri_field or 'id'
+            content['id_field'] = p.title_field
 
             content = render_j2_template(self.config,
                                          'collections/items/index.html',
@@ -1193,10 +1195,10 @@ class API:
 
             content['title'] = collections[dataset]['title']
             content['id_field'] = p.id_field
+            if p.uri_field is not None:
+                content['uri_field'] = p.uri_field
             if p.title_field is not None:
                 content['title_field'] = p.title_field
-            if p.uri_field is not None:
-                content['properties'] = {'uri': uri, **content['properties']}
 
             content = render_j2_template(self.config,
                                          'collections/items/item.html',

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -987,7 +987,7 @@ class API:
             'title': 'This document as HTML',
             'href': '{}/collections/{}/items?f=html{}'.format(
                 self.config['server']['url'], dataset, serialized_query_params)
-           }
+            }
         ]
 
         if startindex > 0:
@@ -2009,7 +2009,7 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
         else:
             LOGGER.debug(data_dict)
 
-        job_id = str(uuid.uuid1())
+        job_id = data.get("job_id", str(uuid.uuid1()))
         url = '{}/processes/{}/jobs/{}'.format(
             self.config['server']['url'], process_id, job_id)
 

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -209,12 +209,23 @@ def geojson2geojsonld(config, data, dataset, identifier=None, identifier_field='
  
     if not geojsonld:
         ldjsonData = {
-            "@context": [{identifier_field: "@id", "schema":"https://schema.org/"},  *(context or []), *(geocontext or [])],
+            "@context": [
+                {
+                "schema":"https://schema.org/",
+                identifier_field: "@id",
+                "type": "@type",
+                },
+                *(context or []),
+                *(geocontext or [])
+            ],
             **data
         }
     else:
         ldjsonData = {
-            "@context": [defaultVocabulary, *(context or []), *(geocontext or [])],
+            "@context": [
+                defaultVocabulary,
+                *(context or [])
+            ],
             **data
         }
 
@@ -224,6 +235,8 @@ def make_jsonld( feature ):
     # Expand properties block
     feature = {**feature, **feature.get('properties')}
     feature.pop('properties')
+
+    feature['type'] = 'schema:Place'
 
     # Remove non-point geometry
     if feature.get('geometry').get('type').lower() != 'point':

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -177,11 +177,6 @@ def geojson2geojsonld(config, data, dataset, identifier=None, identifier_field='
     """
     context = config['resources'][dataset].get('context', [])
     geojsonld = config['resources'][dataset].get('geojsonld', True)
-    geocontext = []
-
-    if data.get('timeStamp', False):
-        data['https://schema.org/sdDatePublished'] = data.pop('timeStamp')
-    defaultVocabulary = "https://geojson.org/geojson-ld/geojson-context.jsonld"
 
     if identifier:
     # Single geojsonld
@@ -192,6 +187,8 @@ def geojson2geojsonld(config, data, dataset, identifier=None, identifier_field='
             data['id'] = identifier
     else:
     # Collection of geojsonld
+        data['@id'] = '{}/collections/{}/items/'.format(
+            config['server']['url'], dataset)
         for i, feature in enumerate(data['features']):
             identifier = feature.get(identifier_field, feature.get('properties').get(identifier_field, ''))
             if not is_url(str(identifier)):
@@ -206,7 +203,11 @@ def geojson2geojsonld(config, data, dataset, identifier=None, identifier_field='
                 feature['id'] = identifier
            
             data['features'][i] = feature
- 
+
+    if data.get('timeStamp', False):
+        data['https://schema.org/sdDatePublished'] = data.pop('timeStamp')
+
+    defaultVocabulary = "https://geojson.org/geojson-ld/geojson-context.jsonld"
     if not geojsonld:
         ldjsonData = {
             "@context": [

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -209,7 +209,7 @@ def geojson2geojsonld(config, data, dataset, identifier=None, identifier_field='
  
     if not geojsonld:
         ldjsonData = {
-            "@context": [{identifier_field: "@id", "schema":"https://schema.org"},  *(context or []), *(geocontext or [])],
+            "@context": [{identifier_field: "@id", "schema":"https://schema.org/"},  *(context or []), *(geocontext or [])],
             **data
         }
     else:

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -53,6 +53,7 @@ class BaseProvider:
 
         self.options = provider_def.get('options', None)
         self.id_field = provider_def.get('id_field', None)
+        self.uri_field = provider_def.get('uri_field', None)
         self.x_field = provider_def.get('x_field', None)
         self.y_field = provider_def.get('y_field', None)
         self.time_field = provider_def.get('time_field')

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -146,7 +146,7 @@ class SQLiteGPKGProvider(BaseProvider):
                 rd.pop('AsGeoJSON({})'.format(self.geom_col))
                 )
             feature['properties'] = rd
-            feature['id'] = str(feature['properties'].pop(self.id_field))
+            feature['id'] = feature['properties'].pop(self.id_field)
 
             return feature
         else:

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -146,7 +146,7 @@ class SQLiteGPKGProvider(BaseProvider):
                 rd.pop('AsGeoJSON({})'.format(self.geom_col))
                 )
             feature['properties'] = rd
-            feature['id'] = feature['properties'].pop(self.id_field)
+            feature['id'] = str(feature['properties'].pop(self.id_field))
 
             return feature
         else:

--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -73,7 +73,7 @@
           <table class="striped">
             <thead>
             <tr>
-                <th>id</th>
+                <th>{{ data['id_field'] }}</th>
                 {% if data['title_field'] %}
                   <th>{{ data['title_field'] }}</th>
                 {% endif %}
@@ -88,8 +88,12 @@
           <tbody>
             {% for ft in data['features'] %}
               <tr>
+                {% if data.get('id_field') != 'id' %}
+                <td data-label="{{ data.get('id_field') }}"><a href="{{ ft.get('properties').get(data.get('id_field'))}}" title="{{ ft.id }}">{{ft['properties'][data.get('id_field')]}}</a></td>
+                {% else %}
                 <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}" title="{{ ft.id }}">{{ ft.id | string | truncate( 12 )  }}</a></td>
-                {% if data['title_field'] %}
+                {% endif %}
+                  {% if data['title_field'] %}
                   <td data-label="name"><a href="{{ data['items_path']}}/{{ ft['id'] }}" title="{{ ft['properties'][data['title_field']] }}">{{ ft['properties'][data['title_field']] | string | truncate( 35 ) }}</a></td>
                 {% endif %}
                 {% for k, v in ft['properties'].items() %}

--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -73,13 +73,16 @@
           <table class="striped">
             <thead>
             <tr>
-                <th>{{ data['id_field'] }}</th>
+              {% if data.get('uri_field') %}
+              <th>{{ data['uri_field'] }}</th>
+              {% endif %}
+                <th>id</th>
                 {% if data['title_field'] %}
                   <th>{{ data['title_field'] }}</th>
                 {% endif %}
                 {% for k, v in data['features'][0]['properties'].items() %}
                   {# start with id & title then take first 5 columns for table #}
-                  {% if loop.index < 5 and k != data['id_field'] and k != data['title_field'] %}
+                  {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], data['uri_field'], 'extent'] %}
                   <th>{{ k }}</th>
                   {% endif %}
                 {% endfor %}
@@ -88,16 +91,15 @@
           <tbody>
             {% for ft in data['features'] %}
               <tr>
-                {% if data.get('id_field') != 'id' %}
-                <td data-label="{{ data.get('id_field') }}"><a href="{{ ft.get('properties').get(data.get('id_field'))}}" title="{{ ft.id }}">{{ft['properties'][data.get('id_field')]}}</a></td>
-                {% else %}
-                <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}" title="{{ ft.id }}">{{ ft.id | string | truncate( 12 )  }}</a></td>
+                {% if data.get('uri_field') %}
+                <td data-label="{{ data.get('uri_field') }}"><a href="{{ ft['properties'].get(data['uri_field'])}}" title="{{ ft['properties'][data['uri_field']] }}">{{ft['properties'][data.get('uri_field')]}}</a></td>
                 {% endif %}
-                  {% if data['title_field'] %}
+                <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}" title="{{ ft.id }}">{{ ft.id | string | truncate( 12 )  }}</a></td>
+                {% if data['title_field'] %}
                   <td data-label="name"><a href="{{ data['items_path']}}/{{ ft['id'] }}" title="{{ ft['properties'][data['title_field']] }}">{{ ft['properties'][data['title_field']] | string | truncate( 35 ) }}</a></td>
                 {% endif %}
                 {% for k, v in ft['properties'].items() %}
-                  {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], 'extent'] %}
+                  {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], data['uri_field'], 'extent'] %}
                   <td data-label="{{ k }}">{{ v | string | truncate( 35 ) }}</td>
                   {% endif %}
                 {% endfor %}

--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -77,6 +77,12 @@
               </tr>
             </thead>
             <tbody>
+            {% if data.uri_field %}
+              <tr>
+                <td>{{ data.uri_field }}</td>
+                <td><a href="{{ data['properties'].get(data.uri_field) }}" title="{{ data['properties'].get(data.uri_field) }}">{{ data['properties'].pop(data.uri_field) }}</a></td>
+              </tr>
+              {% endif %}
               <tr>
                 <td>id</td>
                 <td>{{ data.id }}</td>
@@ -86,7 +92,7 @@
                 <tr>
                   <td>{{ k }}</td>
                   {% if k in ['links', 'associations'] %}
-                  <td> 
+                  <td>
                     <ul>
                       {% for l in v %}
                         {% if l['href'] %}


### PR DESCRIPTION
This PR attempts to update #465 to `master`, in order to support external/global identifiers in the JSON-LD and HTML representations of individual features and to support the JSON-LD use cases of @ksonda and @dblodgett-usgs, which involve standard JSON-LD and not GeoJSON-LD. This PR represents a number of behavior changes which are intertwined.

1. To address #384 and #457, an optional boolean `geojsonld` option is now obtained from the configuration which changes the JSON-LD representation. This option does not change HTML or JSON representations.  This option allows the user to choose between providing JSON-LD data about a real-world feature that is located at a certain geometry (`geojsonld: False`), versus providing JSON-LD data about a particular GeoJSON feature which has attributes that may or may not have semantic specifications (`geojsonld: True`; i.e. the default/current behavior). When `geosjonld:True` or unspecified, the current behavior is preserved as default. When `geojsonld:False`...
 - If the geometry is non-point, the geometry is omitted from the JSON-LD, since non-point geometry is not proper JSON-LD
 - If the geometry is point, the geojson vocabulary in the default context is replaced with schema.org specifications sufficient to represent the feature as a https://schema.org/Place associated with geometry of type https://schema.org/GeoCoordinates. 
 - The `properties` block is removed in favor of representing all feature attributes on the same level as `@id` and `@type`. The default behavior results in all feature attributes being represented in a blank node. This is not the desired behavior for linked data provision, if feature attributes are meant to be RDF predicates with `@id` as their subject.
 


2. To address #433, optional `uri_field` is obtained from configuration to support custom URIs for features, which determine JSON-LD `@id` at the level of individual features, and canonical URL in item html templates. 
3. To address #453, when `uri_field` is specified a `uri` property is created in item tables that link to the pygeoapi item itself. 

Documentation on how to use these two options is added to `configuration.rst`

The way that `geojsonld` and `uri_field` interact can be shown with the demo deployment available on Dockerhub: webbben/pygeoapi-uri:

`docker run -p 5000:80 --rm webbben/pygeoapi-uri`